### PR TITLE
Validation: Autoriser code postal de 4 chiffres

### DIFF
--- a/src/form-data.json
+++ b/src/form-data.json
@@ -60,7 +60,7 @@
       "autocomplete": "postal-code",
       "placeholder": "75001",
       "inputmode": "numeric",
-      "pattern": "[0-9]{5}",
+      "pattern": "[0-9]{4,5}",
       "min": 1000,
       "max": 99999,
       "minlength": 4,


### PR DESCRIPTION
Ce formulaire est a visé internationale et de nombreux pays utilisent des codes postaux
de plus ou moins de 5 chiffres. Le `minlength` et `maxlength` le confirment, mais la regex
de `pattern` force 5 chiffres.

Fixes #1.

---

*À tester* avant mise en production, je n'ai pas testé moi même. Je me suis basé sur https://stackoverflow.com/a/13874904 pour modifier la regex.